### PR TITLE
Add endpoint for downloading Varnam Symbol Table, Removing Word, Cache Improvements

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -18,6 +18,8 @@ const (
 type Cache interface {
 	Set(lang, word string, val ...string) error
 	Get(lang, word string) ([]string, error)
+	Delete(lang, word string) (bool, error)
+	Clear()
 }
 
 // MemCache impliments Cache interface.
@@ -55,4 +57,14 @@ func (c *MemCache) Get(lang, word string) ([]string, error) {
 	}
 
 	return strings.Split(string(val), wordSeparator), nil
+}
+
+func (c *MemCache) Delete(lang, word string) (bool, error) {
+	var key = fmt.Sprintf("%s-%s", lang, word)
+	affected := c.fc.Del([]byte(key))
+	return affected, nil
+}
+
+func (c *MemCache) Clear() {
+	c.fc.Clear()
 }

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -315,6 +315,8 @@ func handleTrain(c echo.Context) error {
 
 	go func(args trainArgs) { ch <- args }(targs)
 
+	app.cache.Delete(langCode, targs.Pattern)
+
 	return c.JSON(200, "Word Trained")
 }
 
@@ -378,6 +380,8 @@ func handleDelete(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error: %s", err.Error()))
 	}
+
+	app.cache.Clear()
 
 	return c.JSON(http.StatusOK, "success")
 }

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -265,7 +265,7 @@ func handleLanguageDownload(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error: %s", err.Error()))
 	}
 
-	return c.Attachment(filepath.(string), langCode + ".vst")
+	return c.Attachment(filepath.(string), langCode+".vst")
 }
 
 func handleLearn(c echo.Context) error {
@@ -376,8 +376,8 @@ func handleDelete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error getting metadata. message: %s", err.Error()))
 	}
 
-	_, err := deleteWord(a.LangCode, a.Text)
-	if err != nil {
+	if _, err := deleteWord(a.LangCode, a.Text); err != nil {
+		app.log.Printf("error deleting word, err: %s", err.Error())
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error: %s", err.Error()))
 	}
 

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -255,6 +255,19 @@ func handleLanguages(c echo.Context) error {
 	return c.JSON(http.StatusOK, schemeDetails)
 }
 
+func handleLanguageDownload(c echo.Context) error {
+	var (
+		langCode = c.Param("langCode")
+	)
+
+	filepath, err = getSchemeFilePath(langCode)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error: %s", err.Error()))
+	}
+
+	return c.File(filepath)
+}
+
 func handleLearn(c echo.Context) error {
 	var (
 		a args

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -359,6 +359,29 @@ func handleTrainBulk(c echo.Context) error {
 	return c.JSON(200, "Words Trained")
 }
 
+// Delete a word
+func handleDelete(c echo.Context) error {
+	var (
+		a args
+
+		app = c.Get("app").(*App)
+	)
+
+	c.Request().Header.Set("Content-Type", "application/json")
+
+	if err := c.Bind(&a); err != nil {
+		app.log.Printf("error in binding request details for delete, err: %s", err.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error getting metadata. message: %s", err.Error()))
+	}
+
+	_, err := deleteWord(a.LangCode, a.Text)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error: %s", err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, "success")
+}
+
 func toggleDownloadEnabledStatus(langCode string, status bool) (interface{}, error) {
 	if err := varnamdConfig.setDownloadStatus(langCode, status); err != nil {
 		return nil, err

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -260,12 +260,12 @@ func handleLanguageDownload(c echo.Context) error {
 		langCode = c.Param("langCode")
 	)
 
-	filepath, err = getSchemeFilePath(langCode)
+	filepath, err := getSchemeFilePath(langCode)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error: %s", err.Error()))
 	}
 
-	return c.File(filepath)
+	return c.Attachment(filepath.(string), langCode + ".vst")
 }
 
 func handleLearn(c echo.Context) error {

--- a/libvarnam/libvarnam.go
+++ b/libvarnam/libvarnam.go
@@ -46,6 +46,11 @@ func (v *Varnam) GetSuggestionsFilePath() string {
 	return C.GoString(C.varnam_get_suggestions_file(v.handle))
 }
 
+// GetSchemeFilePath returns the scheme file (.vst)
+func (v *Varnam) GetSchemeFilePath() string {
+	return C.GoString(C.varnam_get_scheme_file(v.handle))
+}
+
 // GetCorpusDetails will return corpus details.
 func (v *Varnam) GetCorpusDetails() (*CorpusDetails, error) {
 	var details *C.vcorpus_details

--- a/libvarnam/libvarnam.go
+++ b/libvarnam/libvarnam.go
@@ -180,6 +180,19 @@ func (v *Varnam) Learn(text string) error {
 	return nil
 }
 
+// Learn from given input text.
+func (v *Varnam) DeleteWord(text string) error {
+	rc := C.varnam_delete_word(v.handle, C.CString(text))
+
+	if rc != 0 {
+		errorCode := (int)(rc)
+
+		return &VarnamError{errorCode: errorCode, message: v.getVarnamError(errorCode)}
+	}
+
+	return nil
+}
+
 func (v *Varnam) getVarnamError(errorCode int) string {
 	errormessage := C.varnam_get_last_error(v.handle)
 	varnamErrorMsg := C.GoString(errormessage)

--- a/server.go
+++ b/server.go
@@ -36,6 +36,7 @@ func initHandlers(app *App, enableInternalApis bool) *echo.Echo {
 	e.GET("/download/:langCode/:downloadStart", handleDownload)
 	e.POST("/learn", handleLearn)
 	e.GET("/languages", handleLanguages)
+	e.GET("/languages/:langCode/download", handleLanguageDownload)
 	e.GET("/status", handleStatus)
 	e.POST("/train/:langCode", authUser(handleTrain))
 	e.POST("/train/bulk/:langCode", authUser(handleTrainBulk))

--- a/server.go
+++ b/server.go
@@ -34,12 +34,14 @@ func initHandlers(app *App, enableInternalApis bool) *echo.Echo {
 	e.GET("/rtl/:langCode/:word", handleReverseTransliteration)
 	e.GET("/meta/:langCode:", handleMetadata)
 	e.GET("/download/:langCode/:downloadStart", handleDownload)
-	e.POST("/learn", handleLearn)
 	e.GET("/languages", handleLanguages)
 	e.GET("/languages/:langCode/download", handleLanguageDownload)
 	e.GET("/status", handleStatus)
+
+	e.POST("/learn", handleLearn)
 	e.POST("/train/:langCode", authUser(handleTrain))
 	e.POST("/train/bulk/:langCode", authUser(handleTrainBulk))
+	e.POST("/delete", authUser(handleDelete))
 
 	e.GET("/", handleIndex)
 

--- a/varnam_handlers.go
+++ b/varnam_handlers.go
@@ -182,3 +182,9 @@ func getSchemeFilePath(schemeIdentifier string) (interface{}, error) {
 		return handle.GetSchemeFilePath(), nil
 	})
 }
+
+func deleteWord(schemeIdentifier string, word string) (interface{}, error) {
+	return getOrCreateHandler(schemeIdentifier, func(handle *libvarnam.Varnam) (data interface{}, err error) {
+		return nil, handle.DeleteWord(word)
+	})
+}

--- a/varnam_handlers.go
+++ b/varnam_handlers.go
@@ -177,8 +177,8 @@ func sendHandlerToChannel(schemeIdentifier string, handle *libvarnam.Varnam, ch 
 	}
 }
 
-func getSchemeFilePath(schemeIdentifier string) {
+func getSchemeFilePath(schemeIdentifier string) (interface{}, error) {
 	return getOrCreateHandler(schemeIdentifier, func(handle *libvarnam.Varnam) (data interface{}, err error) {
-		return handle.GetSchemeFilePath(schemeIdentifier), nil
+		return handle.GetSchemeFilePath(), nil
 	})
 }

--- a/varnam_handlers.go
+++ b/varnam_handlers.go
@@ -176,3 +176,9 @@ func sendHandlerToChannel(schemeIdentifier string, handle *libvarnam.Varnam, ch 
 	default:
 	}
 }
+
+func getSchemeFilePath(schemeIdentifier string) {
+	return getOrCreateHandler(schemeIdentifier, func(handle *libvarnam.Varnam) (data interface{}, err error) {
+		return handle.GetSchemeFilePath(schemeIdentifier), nil
+	})
+}


### PR DESCRIPTION
* Use `/languages/identifier/download` to download the language symbol table. Example : https://api.varnamproject.com/languages/ml/download
* `/delete` POST {lang: string, text: string}