### PR TITLE
Language pack download

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@
     key-file-path               = ""
     max-handles                 = 10
     upstream-url                = "https://api.varnamproject.com"
+    #upstream-url                = "http://127.0.0.1:8124"
     download-enabled-schemes    = ""
     sync-interval               = "30s"
     accounts-enabled            = false

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -515,7 +515,7 @@ func handlePacks(c echo.Context) error {
 	)
 
 	if langCode != "" {
-		pack, err := getPackInfo(langCode)
+		pack, err := getPacksInfoLang(langCode)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -530,13 +530,28 @@ func handlePacks(c echo.Context) error {
 	return c.JSON(http.StatusOK, packs)
 }
 
+func handlePackInfo(c echo.Context) error {
+	var (
+		langCode       = c.Param("langCode")
+		packIdentifier = c.Param("packIdentifier")
+	)
+
+	pack, err := getPackInfo(langCode, packIdentifier)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, pack)
+}
+
 func handlePackVersionInfo(c echo.Context) error {
 	var (
 		langCode              = c.Param("langCode")
+		packIdentifier        = c.Param("packIdentifier")
 		packVersionIdentifier = c.Param("packVersionIdentifier")
 	)
 
-	pack, err := getPackVersionInfo(langCode, packVersionIdentifier)
+	pack, err := getPackVersionInfo(langCode, packIdentifier, packVersionIdentifier)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -546,15 +561,16 @@ func handlePackVersionInfo(c echo.Context) error {
 
 func handlePacksDownload(c echo.Context) error {
 	var (
-		packVersionIdentifier = c.Param("packVersionIdentifier")
 		langCode              = c.Param("langCode")
+		packIdentifier        = c.Param("packIdentifier")
+		packVersionIdentifier = c.Param("packVersionIdentifier")
 	)
 
-	if _, err := getPackInfo(langCode); err != nil {
+	if _, err := getPackVersionInfo(langCode, packIdentifier, packVersionIdentifier); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	packFilePath, err := getPackFilePath(langCode, packVersionIdentifier)
+	packFilePath, err := getPackFilePath(langCode, packIdentifier, packVersionIdentifier)
 
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -517,7 +517,12 @@ func handlePacks(c echo.Context) error {
 	if langCode != "" {
 		pack, err := getPacksInfoLang(langCode)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+			statusCode := http.StatusBadRequest
+			if err.Error() == "No packs found" {
+				statusCode = http.StatusNotFound
+			}
+
+			return echo.NewHTTPError(statusCode, err.Error())
 		}
 		return c.JSON(http.StatusOK, pack)
 	}
@@ -538,7 +543,12 @@ func handlePackInfo(c echo.Context) error {
 
 	pack, err := getPackInfo(langCode, packIdentifier)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		statusCode := http.StatusBadRequest
+		if err.Error() == "Pack not found" {
+			statusCode = http.StatusNotFound
+		}
+
+		return echo.NewHTTPError(statusCode, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, pack)
@@ -553,7 +563,12 @@ func handlePackVersionInfo(c echo.Context) error {
 
 	pack, err := getPackVersionInfo(langCode, packIdentifier, packVersionIdentifier)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		statusCode := http.StatusBadRequest
+		if err.Error() == "Pack version not found" {
+			statusCode = http.StatusNotFound
+		}
+
+		return echo.NewHTTPError(statusCode, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, pack)

--- a/packs.go
+++ b/packs.go
@@ -129,7 +129,7 @@ func getPackInfo(langCode string, packIdentifier string) (*Pack, error) {
 		}
 	}
 
-	return nil, errors.New("Pack not found")
+	return nil, fmt.Errorf("Pack not found")
 }
 
 // Get packs by language
@@ -146,6 +146,10 @@ func getPacksInfoLang(langCode string) ([]Pack, error) {
 		if pack.LangCode == langCode {
 			langPacks = append(langPacks, pack)
 		}
+	}
+
+	if len(langPacks) == 0 {
+		return nil, fmt.Errorf("No packs found")
 	}
 
 	return langPacks, nil

--- a/packs.go
+++ b/packs.go
@@ -13,19 +13,19 @@ import (
 
 // PackVersion Details of a pack version
 type PackVersion struct {
-	Identifier  string // Pack identifier is unique across all language packs. Example: ml-basic-1
-	Version     int
-	Description string
-	Size        int
+	Identifier  string `json:"identifier"` // Pack identifier is unique across all language packs. Example: ml-basic-1
+	Version     int    `json:"version"`
+	Description string `json:"description"`
+	Size        int    `json:"size"`
 }
 
 // Pack Details of a pack
 type Pack struct {
-	Identifier  string
-	Name        string
-	Description string
-	LangCode    string
-	Versions    []PackVersion
+	Identifier  string        `json:"identifier"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	LangCode    string        `json:"lang"`
+	Versions    []PackVersion `json:"versions"`
 }
 
 type packDownload struct {

--- a/packs.go
+++ b/packs.go
@@ -51,7 +51,7 @@ func updatePacksInfo(langCode string, pack *Pack, packVersion *PackVersion) erro
 	for index, packR := range packs {
 		if packR.Identifier == pack.Identifier {
 			existingPackIndex = index
-			existingPack = pack
+			existingPack = &packR
 			break
 		}
 	}
@@ -88,6 +88,11 @@ func downloadPackFile(langCode string, packIdentifier string, packVersionIdentif
 		pack        *Pack
 		packVersion *PackVersion = nil
 	)
+
+	packInstalled, _ := getPackVersionInfo(langCode, packIdentifier, packVersionIdentifier)
+	if packInstalled != nil {
+		return nil, nil, "", fmt.Errorf("Pack already installed")
+	}
 
 	packInfoURL := fmt.Sprintf("%s/packs/%s/%s", varnamdConfig.upstream, langCode, packIdentifier)
 

--- a/packs.go
+++ b/packs.go
@@ -37,6 +37,11 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
+// After a new pack download from upstream, update packs.json with installed packs
+func updatePacksInfo(langCode string, pack PackVersion) {
+
+}
+
 // Download pack from upstream
 func downloadPackFile(langCode string, packVersionIdentifier string) (string, error) {
 	fileURL := fmt.Sprintf("%s/packs/%s/%s", varnamdConfig.upstream, langCode, packVersionIdentifier)
@@ -73,8 +78,8 @@ func downloadPackFile(langCode string, packVersionIdentifier string) (string, er
 	return filePath, nil
 }
 
-func getPackFilePath(langCode string, packVersionIdentifier string) (string, error) {
-	if _, err := getPackVersionInfo(langCode, packVersionIdentifier); err != nil {
+func getPackFilePath(langCode string, packIdentifier string, packVersionIdentifier string) (string, error) {
+	if _, err := getPackVersionInfo(langCode, packIdentifier, packVersionIdentifier); err != nil {
 		return "", err
 	}
 
@@ -88,8 +93,8 @@ func getPackFilePath(langCode string, packVersionIdentifier string) (string, err
 	return packFilePath, nil
 }
 
-func getPackVersionInfo(langCode string, packVersionIdentifier string) (*PackVersion, error) {
-	pack, err := getPackInfo(langCode)
+func getPackVersionInfo(langCode string, packIdentifier string, packVersionIdentifier string) (*PackVersion, error) {
+	pack, err := getPackInfo(langCode, packIdentifier)
 
 	if err != nil {
 		return nil, err
@@ -111,20 +116,39 @@ func getPackVersionInfo(langCode string, packVersionIdentifier string) (*PackVer
 	return packVersion, nil
 }
 
-func getPackInfo(langCode string) (*Pack, error) {
-	packs, err := getPacksInfo()
+func getPackInfo(langCode string, packIdentifier string) (*Pack, error) {
+	packs, err := getPacksInfoLang(langCode)
 
 	if err != nil {
 		return nil, err
 	}
 
 	for _, pack := range packs {
-		if pack.LangCode == langCode {
+		if pack.Identifier == packIdentifier {
 			return &pack, nil
 		}
 	}
 
 	return nil, errors.New("Pack not found")
+}
+
+// Get packs by language
+func getPacksInfoLang(langCode string) ([]Pack, error) {
+	packs, err := getPacksInfo()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var langPacks []Pack
+
+	for _, pack := range packs {
+		if pack.LangCode == langCode {
+			langPacks = append(langPacks, pack)
+		}
+	}
+
+	return langPacks, nil
 }
 
 func getPacksInfo() ([]Pack, error) {

--- a/server.go
+++ b/server.go
@@ -38,8 +38,9 @@ func initHandlers(app *App, enableInternalApis bool) *echo.Echo {
 	e.GET("/languages/:langCode/download", handleLanguageDownload)
 	e.GET("/packs", handlePacks)
 	e.GET("/packs/:langCode", handlePacks)
-	e.GET("/packs/:langCode/:packVersionIdentifier", handlePackVersionInfo)
-	e.GET("/packs/:langCode/:packVersionIdentifier/download", handlePacksDownload)
+	e.GET("/packs/:langCode/:packIdentifier", handlePackInfo)
+	e.GET("/packs/:langCode/:packIdentifier/:packVersionIdentifier", handlePackVersionInfo)
+	e.GET("/packs/:langCode/:packIdentifier/:packVersionIdentifier/download", handlePacksDownload)
 	e.GET("/status", handleStatus)
 
 	e.GET("/", handleIndex)

--- a/varnam_learn.go
+++ b/varnam_learn.go
@@ -51,7 +51,7 @@ func (app *App) listenForWords(lang string, handle *libvarnam.Varnam) {
 	}
 }
 
-func learnWordsFromFile(c echo.Context, langCode string, fileToLearn string) {
+func learnWordsFromFile(c echo.Context, langCode string, fileToLearn string, removeFile bool) {
 	c.Response().WriteHeader(http.StatusOK)
 
 	start := time.Now()
@@ -73,8 +73,10 @@ func learnWordsFromFile(c echo.Context, langCode string, fileToLearn string) {
 			sendOutput(fmt.Sprintf("Learned from '%s'. TotalWords: %d, Failed: %d. Took %s\n", fileToLearn, learnStatus.TotalWords, learnStatus.Failed, end.Sub(start)))
 		}
 
-		if err = os.Remove(fileToLearn); err != nil {
-			sendOutput(fmt.Sprintf("Error deleting '%s'. %s\n", fileToLearn, err.Error()))
+		if removeFile {
+			if err = os.Remove(fileToLearn); err != nil {
+				sendOutput(fmt.Sprintf("Error deleting '%s'. %s\n", fileToLearn, err.Error()))
+			}
 		}
 
 		return


### PR DESCRIPTION
* Better REST API for packs
* When new pack is downloaded from upstream, packs.json is updated
* If pack already imported, then a repeat will be disallowed to prevent duplicate imports