### PR TITLE
Use Trained files in Pack to import

### DIFF
--- a/http_handlers.go
+++ b/http_handlers.go
@@ -619,7 +619,11 @@ func handlePackDownloadRequest(c echo.Context) error {
 	}
 
 	// Learn from pack file and don't remove it
-	importLearningsFromFile(c, args.LangCode, downloadResult.FilePath, false)
+	err = importLearningsFromFile(c, args.LangCode, downloadResult.FilePath, false)
+
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Error importing from '%s'\n", err.Error()))
+	}
 
 	// Add pack.json with the installed pack versions
 	err = updatePacksInfo(args.LangCode, downloadResult.Pack, downloadResult.Version)

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -621,7 +621,7 @@ func handlePackDownloadRequest(c echo.Context) error {
 	// Learn from pack file and don't remove it
 	learnWordsFromFile(c, args.LangCode, downloadResult.FilePath, false)
 
-	// Update packs.json with our new installed pack
+	// Add pack.json with the installed pack versions
 	err = updatePacksInfo(args.LangCode, downloadResult.Pack, downloadResult.Version)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/http_handlers.go
+++ b/http_handlers.go
@@ -619,7 +619,7 @@ func handlePackDownloadRequest(c echo.Context) error {
 	}
 
 	// Learn from pack file and don't remove it
-	learnWordsFromFile(c, args.LangCode, downloadResult.FilePath, false)
+	importLearningsFromFile(c, args.LangCode, downloadResult.FilePath, false)
 
 	// Add pack.json with the installed pack versions
 	err = updatePacksInfo(args.LangCode, downloadResult.Pack, downloadResult.Version)

--- a/libvarnam/libvarnam.go
+++ b/libvarnam/libvarnam.go
@@ -118,6 +118,19 @@ func (v *Varnam) LearnFromFile(filePath string) (*LearnStatus, error) {
 	return &LearnStatus{TotalWords: int(status.total_words), Failed: int(status.failed)}, nil
 }
 
+// ImportFromFile Import learnigns from file (varnam exported file)
+func (v *Varnam) ImportFromFile(filePath string) error {
+	rc := C.varnam_import_learnings_from_file(v.handle, C.CString(filePath))
+
+	if rc != C.VARNAM_SUCCESS {
+		errorCode := (int)(rc)
+
+		return &VarnamError{errorCode: errorCode, message: v.getVarnamError(errorCode)}
+	}
+
+	return nil
+}
+
 // Init initializes varnam bindings.
 func Init(schemeIdentifier string) (*Varnam, error) {
 	var (
@@ -180,7 +193,7 @@ func (v *Varnam) Learn(text string) error {
 	return nil
 }
 
-// Learn from given input text.
+// DeleteWord from given input text.
 func (v *Varnam) DeleteWord(text string) error {
 	rc := C.varnam_delete_word(v.handle, C.CString(text))
 

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func syncRequired() bool {
 // Starts the sync process only if it is not running
 func startSyncDispatcher() {
 	if syncRequired() && !syncDispatcherRunning {
-		sync := newSyncDispatcher(varnamdConfig.syncInterval * time.Second)
+		sync := newSyncDispatcher(varnamdConfig.syncInterval / time.Second)
 		sync.start()
 		sync.runNow() // run one round of sync immediatly rather than waiting for the next interval to occur
 

--- a/packs.go
+++ b/packs.go
@@ -34,6 +34,9 @@ type packDownload struct {
 	FilePath string
 }
 
+// TODO cached packs
+var packsInfoCached []Pack
+
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -71,7 +74,7 @@ func updatePacksInfo(langCode string, pack *Pack, packVersion *PackVersion) erro
 	}
 
 	// Save pack.json
-	packInfoPath := path.Join(getPacksDir(), pack.Identifier, "pack.json")
+	packInfoPath := path.Join(getPacksDir(), pack.LangCode, pack.Identifier, "pack.json")
 	file, err := json.MarshalIndent(pack, "", "  ")
 	if err != nil {
 		return err
@@ -131,7 +134,7 @@ func downloadPackFile(langCode, packIdentifier, packVersionIdentifier string) (p
 	}
 
 	fileURL := fmt.Sprintf("%s/packs/%s/%s/%s/download", varnamdConfig.upstream, langCode, packIdentifier, packVersionIdentifier)
-	fileDir := path.Join(getPacksDir(), langCode)
+	fileDir := path.Join(getPacksDir(), langCode, packIdentifier)
 	filePath := path.Join(fileDir, packVersionIdentifier)
 
 	if !fileExists(fileDir) {

--- a/packs.go
+++ b/packs.go
@@ -50,13 +50,11 @@ func updatePacksInfo(langCode string, pack *Pack, packVersion *PackVersion) erro
 	}
 
 	var (
-		existingPackIndex int
-		existingPack      *Pack = nil
+		existingPack *Pack = nil
 	)
 
-	for index, packR := range packs {
+	for _, packR := range packs {
 		if packR.Identifier == pack.Identifier {
-			existingPackIndex = index
 			existingPack = &packR
 			break
 		}
@@ -65,22 +63,21 @@ func updatePacksInfo(langCode string, pack *Pack, packVersion *PackVersion) erro
 	if existingPack == nil {
 		// will have one element
 		pack.Versions = []PackVersion{*packVersion}
-
-		// Append new pack
-		packs = append(packs, *pack)
 	} else {
 		// Append new pack version
 		existingPack.Versions = append(existingPack.Versions, *packVersion)
 
-		packs[existingPackIndex] = *existingPack
+		pack = existingPack
 	}
 
-	file, err := json.MarshalIndent(packs, "", "  ")
+	// Save pack.json
+	packInfoPath := path.Join(getPacksDir(), pack.Identifier, "pack.json")
+	file, err := json.MarshalIndent(pack, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(getPacksInfoPath(), file, 0644)
+	err = ioutil.WriteFile(packInfoPath, file, 0644)
 	if err != nil {
 		return err
 	}
@@ -177,8 +174,8 @@ func getPackFilePath(langCode, packIdentifier, packVersionIdentifier string) (st
 		return "", err
 	}
 
-	// Example: .varnamd/ml/ml-basic-1
-	packFilePath := path.Join(getPacksDir(), langCode, packVersionIdentifier)
+	// Example: .varnamd/ml/ml-basic/ml-basic-1
+	packFilePath := path.Join(getPacksDir(), langCode, packIdentifier, packVersionIdentifier)
 
 	if !fileExists(packFilePath) {
 		return "", errors.New("Pack file not found")
@@ -255,31 +252,43 @@ func getPacksInfo() ([]Pack, error) {
 		return nil, err
 	}
 
-	packsFilePath := getPacksInfoPath()
-
-	if !fileExists(packsFilePath) {
-		file, err := os.Create(packsFilePath)
-		if err != nil {
-			return nil, err
-		}
-		file.WriteString("[]")
-		defer file.Close()
-	}
-
-	packsFile, _ := ioutil.ReadFile(packsFilePath)
-
 	var packsInfo []Pack
 
-	if err := json.Unmarshal(packsFile, &packsInfo); err != nil {
-		err := fmt.Errorf("Parsing packs JSON failed, err: %s", err.Error())
+	files, err := ioutil.ReadDir(getPacksDir())
+	if err != nil {
 		return nil, err
 	}
 
-	return packsInfo, nil
-}
+	for _, langFolder := range files {
+		langFolderPath := path.Join(getPacksDir(), langFolder.Name())
+		if langFolder.IsDir() {
+			// inside ml
+			langFolderFiles, err := ioutil.ReadDir(langFolderPath)
 
-func getPacksInfoPath() string {
-	return getPacksDir() + "/packs.json"
+			if err != nil {
+				return nil, err
+			}
+
+			for _, packFolder := range langFolderFiles {
+				if packFolder.IsDir() {
+					packInfoPath := path.Join(langFolderPath, packFolder.Name(), "pack.json")
+					if fileExists(packInfoPath) {
+						var packInfo Pack
+						packsFile, _ := ioutil.ReadFile(packInfoPath)
+
+						if err := json.Unmarshal(packsFile, &packInfo); err != nil {
+							err := fmt.Errorf("Parsing packs JSON failed, err: %s", err.Error())
+							return nil, err
+						}
+
+						packsInfo = append(packsInfo, packInfo)
+					}
+				}
+			}
+		}
+	}
+
+	return packsInfo, nil
 }
 
 func createPacksDir() error {

--- a/packs.go
+++ b/packs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -157,14 +158,20 @@ func downloadPackFile(langCode, packIdentifier, packVersionIdentifier string) (p
 		return packDownload{}, fmt.Errorf(string(respData))
 	}
 
+	fz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return packDownload{}, err
+	}
+	defer fz.Close()
+
 	out, err := os.Create(filePath)
 	if err != nil {
 		return packDownload{}, err
 	}
 	defer out.Close()
 
-	// Write the body to file
-	_, err = io.Copy(out, resp.Body)
+	// Write the gzip decoded content to file
+	_, err = io.Copy(out, fz)
 
 	if err != nil {
 		return packDownload{}, err

--- a/packs.go
+++ b/packs.go
@@ -185,8 +185,8 @@ func getPackFilePath(langCode, packIdentifier, packVersionIdentifier string) (st
 		return "", err
 	}
 
-	// Example: .varnamd/ml/ml-basic/ml-basic-1
-	packFilePath := path.Join(getPacksDir(), langCode, packIdentifier, packVersionIdentifier)
+	// Example: .varnamd/ml/ml-basic/ml-basic-1.vpf
+	packFilePath := path.Join(getPacksDir(), langCode, packIdentifier, packVersionIdentifier) + ".vpf"
 
 	if !fileExists(packFilePath) {
 		return "", errors.New("Pack file not found")

--- a/packs.go
+++ b/packs.go
@@ -34,7 +34,6 @@ type packDownload struct {
 	FilePath string
 }
 
-// TODO cached packs
 var packsInfoCached []Pack
 
 func fileExists(filename string) bool {
@@ -84,6 +83,8 @@ func updatePacksInfo(langCode string, pack *Pack, packVersion *PackVersion) erro
 	if err != nil {
 		return err
 	}
+
+	packsInfoCached = nil
 
 	return nil
 }
@@ -255,6 +256,10 @@ func getPacksInfo() ([]Pack, error) {
 		return nil, err
 	}
 
+	if packsInfoCached != nil {
+		return packsInfoCached, nil
+	}
+
 	var packsInfo []Pack
 
 	files, err := ioutil.ReadDir(getPacksDir())
@@ -290,6 +295,8 @@ func getPacksInfo() ([]Pack, error) {
 			}
 		}
 	}
+
+	packsInfoCached = packsInfo
 
 	return packsInfo, nil
 }

--- a/varnam_learn.go
+++ b/varnam_learn.go
@@ -82,3 +82,35 @@ func learnWordsFromFile(c echo.Context, langCode string, fileToLearn string, rem
 		return
 	})
 }
+
+func importLearningsFromFile(c echo.Context, langCode string, fileToLearn string, removeFile bool) {
+	c.Response().WriteHeader(http.StatusOK)
+
+	start := time.Now()
+
+	sendOutput := func(msg string) {
+		_, _ = c.Response().Write([]byte(msg))
+		c.Response().Flush()
+	}
+
+	sendOutput(fmt.Sprintf("Importing from %s\n", fileToLearn))
+
+	_, _ = getOrCreateHandler(langCode, func(handle *libvarnam.Varnam) (data interface{}, err error) {
+		err = handle.ImportFromFile(fileToLearn)
+		end := time.Now()
+
+		if err != nil {
+			sendOutput(fmt.Sprintf("Error importing from '%s'\n", err.Error()))
+		} else {
+			sendOutput(fmt.Sprintf("Import completed. Took %s\n", end.Sub(start)))
+		}
+
+		if removeFile {
+			if err = os.Remove(fileToLearn); err != nil {
+				sendOutput(fmt.Sprintf("Error deleting '%s'. %s\n", fileToLearn, err.Error()))
+			}
+		}
+
+		return
+	})
+}

--- a/varnam_learn.go
+++ b/varnam_learn.go
@@ -83,7 +83,7 @@ func learnWordsFromFile(c echo.Context, langCode string, fileToLearn string, rem
 	})
 }
 
-func importLearningsFromFile(c echo.Context, langCode string, fileToLearn string, removeFile bool) {
+func importLearningsFromFile(c echo.Context, langCode string, fileToLearn string, removeFile bool) error {
 	c.Response().WriteHeader(http.StatusOK)
 
 	start := time.Now()
@@ -95,12 +95,14 @@ func importLearningsFromFile(c echo.Context, langCode string, fileToLearn string
 
 	sendOutput(fmt.Sprintf("Importing from %s\n", fileToLearn))
 
+	var importError error
+
 	_, _ = getOrCreateHandler(langCode, func(handle *libvarnam.Varnam) (data interface{}, err error) {
 		err = handle.ImportFromFile(fileToLearn)
 		end := time.Now()
 
 		if err != nil {
-			sendOutput(fmt.Sprintf("Error importing from '%s'\n", err.Error()))
+			importError = err
 		} else {
 			sendOutput(fmt.Sprintf("Import completed. Took %s\n", end.Sub(start)))
 		}
@@ -110,7 +112,8 @@ func importLearningsFromFile(c echo.Context, langCode string, fileToLearn string
 				sendOutput(fmt.Sprintf("Error deleting '%s'. %s\n", fileToLearn, err.Error()))
 			}
 		}
-
 		return
 	})
+
+	return importError
 }


### PR DESCRIPTION
Instead of learning words from file, it's more faster to import trained words. This is the better option to use in packs. This PR replaces packs from learning data to importing from varnam exported file.

`--import-learnings-from` is just an import of SQLite data https://github.com/varnamproject/libvarnam#word-corpus

Docs to make a pack : https://github.com/thetronjohnson/varnam/wiki/Making-a-corpus-&-language-pack-for-Varnam