### PR TITLE
.vlf - Varnam Learnings File

### DIFF
--- a/packs.go
+++ b/packs.go
@@ -185,8 +185,8 @@ func getPackFilePath(langCode, packIdentifier, packVersionIdentifier string) (st
 		return "", err
 	}
 
-	// Example: .varnamd/ml/ml-basic/ml-basic-1.vpf
-	packFilePath := path.Join(getPacksDir(), langCode, packIdentifier, packVersionIdentifier) + ".vpf"
+	// Example: .varnamd/ml/ml-basic/ml-basic-1.vlf
+	packFilePath := path.Join(getPacksDir(), langCode, packIdentifier, packVersionIdentifier) + ".vlf"
 
 	if !fileExists(packFilePath) {
 		return "", errors.New("Pack file not found")


### PR DESCRIPTION
**Varnam Learnings File** seems more suited, because the file is obtained from `varnamc --export` and imported with `varnamc --import-learnings-from`. It is after all an export from varnam database, so `learnings` is more suited than a `pack file`.